### PR TITLE
Standardize `Window.onDropFile` in JS.

### DIFF
--- a/src/lime/_internal/backend/html5/HTML5Window.hx
+++ b/src/lime/_internal/backend/html5/HTML5Window.hx
@@ -14,6 +14,7 @@ import js.html.MouseEvent;
 import js.html.Node;
 import js.html.TextAreaElement;
 import js.html.TouchEvent;
+import js.html.URL;
 import js.html.ClipboardEvent;
 import js.Browser;
 import lime._internal.graphics.ImageCanvasUtil;
@@ -459,10 +460,15 @@ class HTML5Window
 				return false;
 
 			case "drop":
-				// TODO: Create a formal API that supports HTML5 file objects
 				if (event.dataTransfer != null && event.dataTransfer.files.length > 0)
 				{
-					parent.onDropFile.dispatch(cast event.dataTransfer.files);
+					parent.onDropStart.dispatch();
+					for (file in event.dataTransfer.files)
+					{
+						parent.onDropFile.dispatch(URL.createObjectURL(file));
+					}
+					parent.onDropEnd.dispatch();
+
 					event.preventDefault();
 					return false;
 				}


### PR DESCRIPTION
Now instead of getting a `FileList` object, you get a string URL just like on other platforms. If the file is an image, this URL can be loaded via `Image.loadFromFile()`, as expected. If not, it can be loaded using any other standard way to load URLs.

Since loading is required either way, I don't believe this hurts performance in any meaningful way. However, it does allocate an object URL that won't be deallocated until the page is closed or the user calls `js.html.URL.revokeObjectURL()`. I'm not too worried about this.